### PR TITLE
Update GitHub workflows to use only ROS2 Jazzy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,17 +232,11 @@ jobs:
 
   build-matrix:
     name: Build Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        ros_distro: [humble, iron, jazzy]
+        ros_distro: [jazzy]
         build_type: [Release, Debug]
-        exclude:
-          # Exclude some combinations to reduce CI time
-          - ros_distro: humble
-            build_type: Debug
-          - ros_distro: iron
-            build_type: Debug
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   core-tests:
-    name: Core Unit Tests
-    runs-on: ubuntu-22.04  # Use 22.04 for better ROS2 support
+    name: Core Unit Tests (ROS2 Jazzy)
+    runs-on: ubuntu-24.04  # Use 24.04 for ROS2 Jazzy
     
     steps:
     - name: Checkout code
@@ -27,18 +27,18 @@ jobs:
           qt6-declarative-dev \
           libqt6xml6-dev
 
-    - name: Setup minimal ROS2 (Humble - Ubuntu 22.04)
+    - name: Setup ROS2 Jazzy (Ubuntu 24.04)
       run: |
         # Add ROS 2 apt repository
         sudo apt-get install -y software-properties-common curl
         curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu jammy main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu noble main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
         
         sudo apt-get update
         sudo apt-get install -y \
-          ros-humble-ros-core \
-          ros-humble-rclcpp \
-          ros-humble-ament-cmake \
+          ros-jazzy-ros-core \
+          ros-jazzy-rclcpp \
+          ros-jazzy-ament-cmake \
           python3-colcon-common-extensions
 
     - name: Install BehaviorTree.CPP
@@ -54,13 +54,13 @@ jobs:
 
     - name: Build BranchForge
       run: |
-        source /opt/ros/humble/setup.bash
+        source /opt/ros/jazzy/setup.bash
         colcon build --packages-select branchforge \
           --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
 
     - name: Run Core Tests
       run: |
-        source /opt/ros/humble/setup.bash
+        source /opt/ros/jazzy/setup.bash
         source install/setup.bash
         
         echo "=== Running BranchForge Core Tests ==="

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   test-ubuntu:
-    name: Test on Ubuntu 22.04
-    runs-on: ubuntu-22.04
+    name: Test on Ubuntu 24.04 (ROS2 Jazzy)
+    runs-on: ubuntu-24.04
     
     steps:
     - name: Checkout code
@@ -29,19 +29,19 @@ jobs:
           python3-pip \
           python3-colcon-common-extensions
 
-    - name: Setup ROS 2 Humble
+    - name: Setup ROS 2 Jazzy
       run: |
         # Add ROS 2 apt repository
         sudo apt-get update
         sudo apt-get install -y software-properties-common curl
         curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu jammy main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu noble main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
         
         sudo apt-get update
         sudo apt-get install -y \
-          ros-humble-ros-core \
-          ros-humble-rclcpp \
-          ros-humble-ament-cmake \
+          ros-jazzy-ros-core \
+          ros-jazzy-rclcpp \
+          ros-jazzy-ament-cmake \
           python3-rosdep \
           python3-colcon-common-extensions
           
@@ -62,13 +62,13 @@ jobs:
 
     - name: Build BranchForge
       run: |
-        source /opt/ros/humble/setup.bash
+        source /opt/ros/jazzy/setup.bash
         colcon build --packages-select branchforge \
           --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
 
     - name: Run Tests
       run: |
-        source /opt/ros/humble/setup.bash
+        source /opt/ros/jazzy/setup.bash
         source install/setup.bash
         
         echo "=== Running BranchForge Unit Tests ==="


### PR DESCRIPTION
- Switch all workflows from Ubuntu 22.04/Humble to Ubuntu 24.04/Jazzy
- Remove multi-distribution matrix (humble, iron) - focus only on Jazzy
- Update core-tests.yml to use Ubuntu 24.04 with proper Jazzy setup
- Update test.yml to use Jazzy with noble (Ubuntu 24.04) repository
- Simplify build-matrix to only test Jazzy with Release/Debug builds
- Align with project requirements for modern ROS2 Jazzy support

🤖 Generated with [Claude Code](https://claude.ai/code)