### PR TITLE
Fix colcon installation for Ubuntu 24.04

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -28,7 +28,9 @@ jobs:
           build-essential \
           cmake \
           pkg-config \
-          libgtest-dev
+          libgtest-dev \
+          python3-pip \
+          python3-setuptools
         
         # Install Qt6 with correct package names for Ubuntu 24.04
         sudo apt-get install -y \
@@ -36,6 +38,12 @@ jobs:
           qt6-declarative-dev \
           libqt6xml6 \
           qt6-tools-dev || echo "⚠️ Some Qt6 packages failed to install"
+
+    - name: Install colcon
+      run: |
+        # Install colcon via pip since apt package doesn't exist on Ubuntu 24.04
+        python3 -m pip install --user --upgrade pip
+        python3 -m pip install --user colcon-common-extensions
 
     - name: Setup ROS2 Jazzy (Ubuntu 24.04)
       run: |
@@ -48,8 +56,7 @@ jobs:
         sudo apt-get install -y \
           ros-jazzy-ros-core \
           ros-jazzy-rclcpp \
-          ros-jazzy-ament-cmake \
-          python3-colcon-common-extensions
+          ros-jazzy-ament-cmake
 
     - name: Install BehaviorTree.CPP
       run: |
@@ -66,6 +73,9 @@ jobs:
       run: |
         source /opt/ros/jazzy/setup.bash
         
+        # Add colcon to PATH
+        export PATH=$HOME/.local/bin:$PATH
+        
         # Clean any existing build cache
         rm -rf build/ install/ log/
         
@@ -76,6 +86,7 @@ jobs:
     - name: Run Core Tests
       run: |
         source /opt/ros/jazzy/setup.bash
+        export PATH=$HOME/.local/bin:$PATH
         source install/setup.bash
         
         echo "=== Running BranchForge Core Tests ==="

--- a/.github/workflows/minimal-test.yml
+++ b/.github/workflows/minimal-test.yml
@@ -24,7 +24,13 @@ jobs:
           pkg-config \
           libgtest-dev \
           python3-pip \
-          python3-colcon-common-extensions
+          python3-setuptools
+
+    - name: Install colcon
+      run: |
+        # Install colcon via pip since apt package doesn't exist on Ubuntu 24.04
+        python3 -m pip install --user --upgrade pip
+        python3 -m pip install --user colcon-common-extensions
 
     - name: Setup ROS2 Jazzy
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           pkg-config \
           libgtest-dev \
           python3-pip \
-          python3-colcon-common-extensions
+          python3-setuptools
         
         # Install Qt6 packages (check availability first)
         echo "=== Installing Qt6 packages ==="
@@ -35,6 +35,12 @@ jobs:
           qt6-declarative-dev \
           libqt6xml6 \
           qt6-tools-dev || echo "⚠️ Some Qt6 packages may not be available"
+
+    - name: Install colcon
+      run: |
+        # Install colcon via pip since apt package doesn't exist on Ubuntu 24.04
+        python3 -m pip install --user --upgrade pip
+        python3 -m pip install --user colcon-common-extensions
 
     - name: Setup ROS 2 Jazzy
       run: |
@@ -49,8 +55,7 @@ jobs:
           ros-jazzy-ros-core \
           ros-jazzy-rclcpp \
           ros-jazzy-ament-cmake \
-          python3-rosdep \
-          python3-colcon-common-extensions
+          python3-rosdep
           
         # Initialize rosdep
         sudo rosdep init || true
@@ -70,6 +75,7 @@ jobs:
     - name: Clean and Build BranchForge
       run: |
         source /opt/ros/jazzy/setup.bash
+        export PATH=$HOME/.local/bin:$PATH
         
         # Clean any existing build cache
         rm -rf build/ install/ log/
@@ -81,6 +87,7 @@ jobs:
     - name: Run Tests
       run: |
         source /opt/ros/jazzy/setup.bash
+        export PATH=$HOME/.local/bin:$PATH
         source install/setup.bash
         
         echo "=== Running BranchForge Unit Tests ==="


### PR DESCRIPTION
- Replace non-existent python3-colcon-common-extensions package
- Install colcon via pip: colcon-common-extensions
- Add PATH=/home/dingo/.local/bin:/home/dingo/.nvm/versions/node/v18.20.8/bin:/home/dingo/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/home/dingo/.local/bin:/home/dingo/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/home/dingo/.config/Code/User/globalStorage/github.copilot-chat/debugCommand for pip-installed colcon
- Add python3-setuptools for proper pip functionality
- Update all workflows: core-tests, test, minimal-test
- Remove python3-colcon-common-extensions from ROS2 dependencies

Fixes: E: Unable to locate package python3-colcon-common-extensions

🤖 Generated with [Claude Code](https://claude.ai/code)