### PR TITLE
Fix ZeroMQ dependency for BehaviorTree.CPP installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,15 +84,19 @@ jobs:
           ros-${{ matrix.ros_distro }}-ament-lint-auto \
           ros-${{ matrix.ros_distro }}-ament-lint-common
 
+    - name: Install ZeroMQ
+      run: |
+        sudo apt-get install -y libzmq3-dev libcppzmq-dev
+
     - name: Install BehaviorTree.CPP
       run: |
         source /opt/ros/${{ matrix.ros_distro }}/setup.bash
         # BehaviorTree.CPP might not be available in ROS packages, install from source
         cd /tmp
-        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.7.2
+        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.6.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_USING_AMENT=OFF
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -58,13 +58,17 @@ jobs:
           ros-jazzy-rclcpp \
           ros-jazzy-ament-cmake
 
+    - name: Install ZeroMQ
+      run: |
+        sudo apt-get install -y libzmq3-dev libcppzmq-dev
+
     - name: Install BehaviorTree.CPP
       run: |
         cd /tmp
-        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.7.2
+        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.6.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_USING_AMENT=OFF
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/minimal-test.yml
+++ b/.github/workflows/minimal-test.yml
@@ -45,13 +45,17 @@ jobs:
           ros-jazzy-rclcpp \
           ros-jazzy-ament-cmake
 
+    - name: Install ZeroMQ
+      run: |
+        sudo apt-get install -y libzmq3-dev libcppzmq-dev
+
     - name: Install BehaviorTree.CPP
       run: |
         cd /tmp
-        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.7.2
+        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.6.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_USING_AMENT=OFF
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,13 +61,17 @@ jobs:
         sudo rosdep init || true
         rosdep update
 
+    - name: Install ZeroMQ
+      run: |
+        sudo apt-get install -y libzmq3-dev libcppzmq-dev
+
     - name: Install BehaviorTree.CPP
       run: |
         cd /tmp
-        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.7.2
+        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.6.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_USING_AMENT=OFF
         make -j$(nproc)
         sudo make install
         sudo ldconfig


### PR DESCRIPTION
- Add ZeroMQ installation (libzmq3-dev, libcppzmq-dev) to all workflows
- Downgrade to BehaviorTree.CPP 4.6.2 for better compatibility
- Add -DBUILD_USING_AMENT=OFF flag to avoid conan dependency issues
- Fixes "Could NOT find ZeroMQ" CMake configuration error

🤖 Generated with [Claude Code](https://claude.ai/code)