### PR TITLE
Use BehaviorTree.CPP 4.5.2 to avoid ZeroMQ dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,19 +84,15 @@ jobs:
           ros-${{ matrix.ros_distro }}-ament-lint-auto \
           ros-${{ matrix.ros_distro }}-ament-lint-common
 
-    - name: Install ZeroMQ
-      run: |
-        sudo apt-get install -y libzmq3-dev libcppzmq-dev
-
     - name: Install BehaviorTree.CPP
       run: |
         source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-        # BehaviorTree.CPP might not be available in ROS packages, install from source
+        # Install from source using older stable version without ZeroMQ dependency
         cd /tmp
-        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.6.2
+        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.5.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_USING_AMENT=OFF
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -58,17 +58,13 @@ jobs:
           ros-jazzy-rclcpp \
           ros-jazzy-ament-cmake
 
-    - name: Install ZeroMQ
-      run: |
-        sudo apt-get install -y libzmq3-dev libcppzmq-dev
-
     - name: Install BehaviorTree.CPP
       run: |
         cd /tmp
-        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.6.2
+        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.5.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_USING_AMENT=OFF
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/minimal-test.yml
+++ b/.github/workflows/minimal-test.yml
@@ -45,17 +45,13 @@ jobs:
           ros-jazzy-rclcpp \
           ros-jazzy-ament-cmake
 
-    - name: Install ZeroMQ
-      run: |
-        sudo apt-get install -y libzmq3-dev libcppzmq-dev
-
     - name: Install BehaviorTree.CPP
       run: |
         cd /tmp
-        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.6.2
+        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.5.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_USING_AMENT=OFF
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,17 +61,13 @@ jobs:
         sudo rosdep init || true
         rosdep update
 
-    - name: Install ZeroMQ
-      run: |
-        sudo apt-get install -y libzmq3-dev libcppzmq-dev
-
     - name: Install BehaviorTree.CPP
       run: |
         cd /tmp
-        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.6.2
+        git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.5.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_USING_AMENT=OFF
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON
         make -j$(nproc)
         sudo make install
         sudo ldconfig


### PR DESCRIPTION
- Remove ZeroMQ installation (libcppzmq-dev doesn't exist on Ubuntu 24.04)
- Use BehaviorTree.CPP 4.5.2 which doesn't require ZeroMQ/conan
- Add -DBUILD_SHARED_LIBS=ON for proper library installation
- Fixes package installation failures in CI workflows

🤖 Generated with [Claude Code](https://claude.ai/code)