### PR TITLE
Force BehaviorTree.CPP to use catkin build instead of conan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,23 @@ jobs:
     - name: Install BehaviorTree.CPP
       run: |
         source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-        # Install from source using older stable version without ZeroMQ dependency
+        # Install from source using catkin build instead of conan
         cd /tmp
         git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.5.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON
+        
+        # Set catkin environment to avoid conan dependency
+        export CATKIN_DEVEL_PREFIX=/opt/ros/${{ matrix.ros_distro }}
+        
+        cmake .. \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTING=OFF \
+          -DBTCPP_EXAMPLES=OFF \
+          -DBTCPP_UNIT_TESTS=OFF \
+          -DBTCPP_GROOT_INTERFACE=OFF \
+          -DBTCPP_SQLITE_LOGGING=OFF \
+          -DBUILD_SHARED_LIBS=ON
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -60,11 +60,23 @@ jobs:
 
     - name: Install BehaviorTree.CPP
       run: |
+        # Install from source using catkin build instead of conan
         cd /tmp
         git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.5.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON
+        
+        # Set catkin environment to avoid conan dependency
+        export CATKIN_DEVEL_PREFIX=/opt/ros/jazzy
+        
+        cmake .. \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTING=OFF \
+          -DBTCPP_EXAMPLES=OFF \
+          -DBTCPP_UNIT_TESTS=OFF \
+          -DBTCPP_GROOT_INTERFACE=OFF \
+          -DBTCPP_SQLITE_LOGGING=OFF \
+          -DBUILD_SHARED_LIBS=ON
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/minimal-test.yml
+++ b/.github/workflows/minimal-test.yml
@@ -47,11 +47,23 @@ jobs:
 
     - name: Install BehaviorTree.CPP
       run: |
+        # Install from source using catkin build instead of conan
         cd /tmp
         git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.5.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON
+        
+        # Set catkin environment to avoid conan dependency
+        export CATKIN_DEVEL_PREFIX=/opt/ros/jazzy
+        
+        cmake .. \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTING=OFF \
+          -DBTCPP_EXAMPLES=OFF \
+          -DBTCPP_UNIT_TESTS=OFF \
+          -DBTCPP_GROOT_INTERFACE=OFF \
+          -DBTCPP_SQLITE_LOGGING=OFF \
+          -DBUILD_SHARED_LIBS=ON
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,11 +63,23 @@ jobs:
 
     - name: Install BehaviorTree.CPP
       run: |
+        # Install from source using catkin build instead of conan
         cd /tmp
         git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git --depth 1 --branch 4.5.2
         cd BehaviorTree.CPP
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON
+        
+        # Set catkin environment to avoid conan dependency
+        export CATKIN_DEVEL_PREFIX=/opt/ros/jazzy
+        
+        cmake .. \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTING=OFF \
+          -DBTCPP_EXAMPLES=OFF \
+          -DBTCPP_UNIT_TESTS=OFF \
+          -DBTCPP_GROOT_INTERFACE=OFF \
+          -DBTCPP_SQLITE_LOGGING=OFF \
+          -DBUILD_SHARED_LIBS=ON
         make -j$(nproc)
         sudo make install
         sudo ldconfig


### PR DESCRIPTION
- Set CATKIN_DEVEL_PREFIX environment variable to trigger catkin build path
- Disable optional features that require ZeroMQ: GROOT_INTERFACE, SQLITE_LOGGING
- Add explicit flags to disable examples and unit tests
- This avoids conan dependency chain that requires ZeroMQ

🤖 Generated with [Claude Code](https://claude.ai/code)