### PR TITLE
Fix Qt6 CMake configuration path for Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
       run: |
         source /opt/ros/${{ matrix.ros_distro }}/setup.bash
         export PATH=$HOME/.local/bin:$PATH
+        export CMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake:$CMAKE_PREFIX_PATH"
         
         # Clean any existing build cache
         rm -rf build/ install/ log/
@@ -138,6 +139,7 @@ jobs:
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
+            -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake" \
           --executor sequential
 
     - name: Run tests with error handling
@@ -324,6 +326,7 @@ jobs:
       run: |
         source /opt/ros/${{ matrix.ros_distro }}/setup.bash
         export PATH=$HOME/.local/bin:$PATH
+        export CMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake:$CMAKE_PREFIX_PATH"
         
         # Clean any existing build cache
         rm -rf build/ install/ log/
@@ -332,6 +335,7 @@ jobs:
           --cmake-args \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DBUILD_TESTING=OFF \
+            -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake" \
           --executor sequential
 
     - name: Check build artifacts

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -87,13 +87,17 @@ jobs:
         
         # Add colcon to PATH
         export PATH=$HOME/.local/bin:$PATH
+        export CMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake:$CMAKE_PREFIX_PATH"
         
         # Clean any existing build cache
         rm -rf build/ install/ log/
         
         # Build with fresh cache
         colcon build --packages-select branchforge \
-          --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+          --cmake-args \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=ON \
+            -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake"
 
     - name: Run Core Tests
       run: |

--- a/.github/workflows/minimal-test.yml
+++ b/.github/workflows/minimal-test.yml
@@ -71,6 +71,7 @@ jobs:
     - name: Try basic build (without Qt6)
       run: |
         source /opt/ros/jazzy/setup.bash
+        export CMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake:$CMAKE_PREFIX_PATH"
         
         # Clean any existing build cache
         rm -rf build/ install/ log/ build-minimal/
@@ -83,6 +84,7 @@ jobs:
         cmake .. \
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_TESTING=ON \
+          -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake" \
           -DSKIP_QT_DEPENDENCIES=ON || echo "⚠️ CMake configuration failed"
         
         # Check if we can at least find core components

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,13 +88,17 @@ jobs:
       run: |
         source /opt/ros/jazzy/setup.bash
         export PATH=$HOME/.local/bin:$PATH
+        export CMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake:$CMAKE_PREFIX_PATH"
         
         # Clean any existing build cache
         rm -rf build/ install/ log/
         
         # Build with fresh cache
         colcon build --packages-select branchforge \
-          --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+          --cmake-args \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=ON \
+            -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake"
 
     - name: Run Tests
       run: |


### PR DESCRIPTION
- Set CMAKE_PREFIX_PATH to /usr/lib/x86_64-linux-gnu/cmake for Qt6 detection
- Add both environment variable and cmake-args configuration
- Fixes "Could not find a package configuration file provided by Qt6" error
- All workflows now include proper Qt6 CMake path resolution

🤖 Generated with [Claude Code](https://claude.ai/code)