### PR TITLE
Use Qt6_DIR instead of CMAKE_PREFIX_PATH for better Qt6 detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
-            -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake" \
+            -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6" \
           --executor sequential
 
     - name: Run tests with error handling
@@ -335,7 +335,7 @@ jobs:
           --cmake-args \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DBUILD_TESTING=OFF \
-            -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake" \
+            -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6" \
           --executor sequential
 
     - name: Check build artifacts

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -97,7 +97,7 @@ jobs:
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
-            -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake"
+            -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6"
 
     - name: Run Core Tests
       run: |

--- a/.github/workflows/minimal-test.yml
+++ b/.github/workflows/minimal-test.yml
@@ -84,7 +84,7 @@ jobs:
         cmake .. \
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_TESTING=ON \
-          -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake" \
+          -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6" \
           -DSKIP_QT_DEPENDENCIES=ON || echo "⚠️ CMake configuration failed"
         
         # Check if we can at least find core components

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
-            -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/cmake"
+            -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6"
 
     - name: Run Tests
       run: |


### PR DESCRIPTION
- Set Qt6_DIR directly to /usr/lib/x86_64-linux-gnu/cmake/Qt6
- Replace CMAKE_PREFIX_PATH approach which wasn't working with colcon
- Direct path to Qt6Config.cmake should resolve CMake find_package issues
- More reliable than relying on CMAKE_PREFIX_PATH traversal

🤖 Generated with [Claude Code](https://claude.ai/code)