### PR TITLE
Fix Qt6 XML dependency and remove non-existent packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
           wget \
           libgtest-dev \
           qt6-base-dev \
-          qt6-declarative-dev \
-          libqt6xml6 \
+          qt6-qmake \
           qt6-tools-dev || echo "⚠️ Some Qt6 packages may not be available"
 
     - name: Install colcon
@@ -317,8 +316,7 @@ jobs:
           build-essential \
           cmake \
           qt6-base-dev \
-          qt6-declarative-dev \
-          libqt6xml6 \
+          qt6-qmake \
           qt6-tools-dev \
           libgtest-dev || echo "⚠️ Some packages may not be available"
 

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -41,11 +41,9 @@ jobs:
           qt6-base-dev \
           qt6-qmake \
           qt6-tools-dev \
-          qt6-l10n-tools \
           libqt6core6-dev \
           libqt6gui6-dev \
           libqt6widgets6-dev \
-          libqt6xml6-dev \
           libqt6opengl6-dev || echo "⚠️ Some Qt6 packages failed to install"
         
         # Try installing Qt6 cmake support specifically

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,7 @@ jobs:
         echo "=== Installing Qt6 packages ==="
         sudo apt-get install -y \
           qt6-base-dev \
-          qt6-declarative-dev \
-          libqt6xml6 \
+          qt6-qmake \
           qt6-tools-dev || echo "⚠️ Some Qt6 packages may not be available"
 
     - name: Install colcon

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Find Qt6 packages
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent Gui Qml Quick Xml)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent Gui Qml Quick)
+# Try to find Xml component separately (may not be available on all systems)
+find_package(Qt6 COMPONENTS Xml QUIET)
 
 qt6_standard_project_setup()
 
@@ -63,8 +65,13 @@ target_link_libraries(branchforge_enhanced PRIVATE
     Qt6::Gui
     Qt6::Qml
     Qt6::Quick
-    Qt6::Xml
 )
+
+# Link Qt6::Xml if available
+if(TARGET Qt6::Xml)
+    target_link_libraries(branchforge_enhanced PRIVATE Qt6::Xml)
+    target_compile_definitions(branchforge_enhanced PRIVATE QT6_XML_AVAILABLE)
+endif()
 
 target_compile_options(branchforge_enhanced PRIVATE
     -Wall -Wextra -Wpedantic


### PR DESCRIPTION
- Remove libqt6xml6-dev and other non-existent packages from workflows
- Make Qt6::Xml component optional in CMakeLists.txt
- Use qt6-qmake instead of qt6-declarative-dev for broader compatibility
- Add conditional linking and QT6_XML_AVAILABLE definition
- Focus on core Qt6 packages that exist on Ubuntu 24.04

🤖 Generated with [Claude Code](https://claude.ai/code)