### PR TITLE
Remove remaining non-existent Qt6 dev packages

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -40,11 +40,7 @@ jobs:
         sudo apt-get install -y \
           qt6-base-dev \
           qt6-qmake \
-          qt6-tools-dev \
-          libqt6core6-dev \
-          libqt6gui6-dev \
-          libqt6widgets6-dev \
-          libqt6opengl6-dev || echo "⚠️ Some Qt6 packages failed to install"
+          qt6-tools-dev || echo "⚠️ Some Qt6 packages failed to install"
         
         # Try installing Qt6 cmake support specifically
         sudo apt-get install -y qt6-base-dev-tools || echo "⚠️ qt6-base-dev-tools not available"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,7 +24,7 @@ jobs:
           cmake \
           libgtest-dev \
           qt6-base-dev \
-          libqt6xml6-dev \
+          qt6-qmake \
           pkg-config
 
     - name: Quick build test (no ROS)


### PR DESCRIPTION
- Fix pr-check.yml: replace libqt6xml6-dev with qt6-qmake
- Fix core-tests.yml: remove libqt6*-dev packages that don't exist
- Use only basic Qt6 packages available on Ubuntu 24.04
- Prevents "Unable to locate package" installation failures

🤖 Generated with [Claude Code](https://claude.ai/code)