### PR TITLE
Make Qt6 QML/Quick components optional for CI compatibility

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -40,8 +40,13 @@ jobs:
         echo -e "\nPackages containing 'qt' and 'dev':"
         apt-cache search qt | grep dev | grep -i qt | head -20
         
+        echo -e "\nQt QML/Quick packages:"
+        apt-cache search qt6 | grep -i qml
+        apt-cache search qt6 | grep -i quick
+        apt-cache search qt6 | grep -i declarative
+        
         echo "\n=== Checking specific Qt6 packages ==="
-        QT6_PACKAGES=("qt6-base-dev" "qt6-tools-dev" "qt6-qmake" "qt6-base-dev-tools" "libqt6core6" "libqt6gui6" "libqt6widgets6" "libqt6xml6" "qmake6")
+        QT6_PACKAGES=("qt6-base-dev" "qt6-tools-dev" "qt6-qmake" "qt6-base-dev-tools" "qt6-declarative-dev" "qt6-quick-dev" "qml6-module-qtquick" "libqt6core6" "libqt6gui6" "libqt6widgets6" "libqt6xml6" "qmake6")
         AVAILABLE_PACKAGES=()
         
         for pkg in "${QT6_PACKAGES[@]}"; do

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Find Qt6 packages
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent Gui Qml Quick)
-# Try to find Xml component separately (may not be available on all systems)
-find_package(Qt6 COMPONENTS Xml QUIET)
+# Find Qt6 packages - start with essential components
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent Gui)
+# Try to find optional components (may not be available on all systems)
+find_package(Qt6 COMPONENTS Qml Quick Xml QUIET)
 
 qt6_standard_project_setup()
 
@@ -16,8 +16,12 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Generate QRC file first
-qt6_add_resources(QML_RESOURCES resources.qrc)
+# Generate QRC file if QML is available
+if(TARGET Qt6::Qml)
+    qt6_add_resources(QML_RESOURCES resources.qrc)
+else()
+    set(QML_RESOURCES "")
+endif()
 
 set(SOURCES
     src/main.cpp
@@ -63,11 +67,19 @@ target_link_libraries(branchforge_enhanced PRIVATE
     Qt6::Widgets
     Qt6::Concurrent
     Qt6::Gui
-    Qt6::Qml
-    Qt6::Quick
 )
 
-# Link Qt6::Xml if available
+# Link optional Qt6 components if available
+if(TARGET Qt6::Qml)
+    target_link_libraries(branchforge_enhanced PRIVATE Qt6::Qml)
+    target_compile_definitions(branchforge_enhanced PRIVATE QT6_QML_AVAILABLE)
+endif()
+
+if(TARGET Qt6::Quick)
+    target_link_libraries(branchforge_enhanced PRIVATE Qt6::Quick)
+    target_compile_definitions(branchforge_enhanced PRIVATE QT6_QUICK_AVAILABLE)
+endif()
+
 if(TARGET Qt6::Xml)
     target_link_libraries(branchforge_enhanced PRIVATE Qt6::Xml)
     target_compile_definitions(branchforge_enhanced PRIVATE QT6_XML_AVAILABLE)


### PR DESCRIPTION
- Split Qt6 find_package into required vs optional components
- Core/Widgets/Concurrent/Gui are required, QML/Quick/Xml are optional
- Add conditional linking and compilation definitions for optional components
- Make QRC resource compilation conditional on QML availability
- Add QML package discovery to workflow debugging
- This allows build to succeed with minimal Qt6 installation

🤖 Generated with [Claude Code](https://claude.ai/code)