### PR TITLE
Apply working Qt6 configuration to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
           wget \
           libgtest-dev \
           qt6-base-dev \
-          qt6-qmake \
           qt6-tools-dev || echo "⚠️ Some Qt6 packages may not be available"
 
     - name: Install colcon
@@ -134,11 +133,22 @@ jobs:
         # Clean any existing build cache
         rm -rf build/ install/ log/
         
+        # Find Qt6 installation
+        QT6_CONFIG=$(find /usr -name "Qt6Config.cmake" -type f 2>/dev/null | head -1)
+        if [ -n "$QT6_CONFIG" ]; then
+          QT6_DIR=$(dirname "$QT6_CONFIG")
+          echo "Found Qt6Config.cmake at: $QT6_DIR"
+          BUILD_ARGS="-DQt6_DIR=$QT6_DIR"
+        else
+          echo "No Qt6Config.cmake found"
+          BUILD_ARGS=""
+        fi
+        
         colcon build --packages-select branchforge \
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
-            -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6" \
+            $BUILD_ARGS \
           --executor sequential
 
     - name: Run tests with error handling
@@ -316,7 +326,6 @@ jobs:
           build-essential \
           cmake \
           qt6-base-dev \
-          qt6-qmake \
           qt6-tools-dev \
           libgtest-dev || echo "⚠️ Some packages may not be available"
 
@@ -329,11 +338,20 @@ jobs:
         # Clean any existing build cache
         rm -rf build/ install/ log/
         
+        # Find Qt6 installation
+        QT6_CONFIG=$(find /usr -name "Qt6Config.cmake" -type f 2>/dev/null | head -1)
+        if [ -n "$QT6_CONFIG" ]; then
+          QT6_DIR=$(dirname "$QT6_CONFIG")
+          BUILD_ARGS="-DQt6_DIR=$QT6_DIR"
+        else
+          BUILD_ARGS=""
+        fi
+        
         colcon build --packages-select branchforge \
           --cmake-args \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DBUILD_TESTING=OFF \
-            -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6" \
+            $BUILD_ARGS \
           --executor sequential
 
     - name: Check build artifacts

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,7 +24,7 @@ jobs:
           cmake \
           libgtest-dev \
           qt6-base-dev \
-          qt6-qmake \
+          qt6-tools-dev \
           pkg-config
 
     - name: Quick build test (no ROS)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
         echo "=== Installing Qt6 packages ==="
         sudo apt-get install -y \
           qt6-base-dev \
-          qt6-qmake \
           qt6-tools-dev || echo "⚠️ Some Qt6 packages may not be available"
 
     - name: Install colcon
@@ -93,11 +92,22 @@ jobs:
         rm -rf build/ install/ log/
         
         # Build with fresh cache
+        # Find Qt6 installation
+        QT6_CONFIG=$(find /usr -name "Qt6Config.cmake" -type f 2>/dev/null | head -1)
+        if [ -n "$QT6_CONFIG" ]; then
+          QT6_DIR=$(dirname "$QT6_CONFIG")
+          echo "Found Qt6Config.cmake at: $QT6_DIR"
+          BUILD_ARGS="-DQt6_DIR=$QT6_DIR"
+        else
+          echo "No Qt6Config.cmake found"
+          BUILD_ARGS=""
+        fi
+        
         colcon build --packages-select branchforge \
           --cmake-args \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=ON \
-            -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6"
+            $BUILD_ARGS
 
     - name: Run Tests
       run: |


### PR DESCRIPTION
- Remove qt6-qmake package (doesn't exist) from all workflows
- Use only qt6-base-dev and qt6-tools-dev (confirmed working)
- Add dynamic Qt6_DIR detection to CI and test workflows
- Copy successful approach from core-tests to all other workflows
- This should make all workflows pass like core-tests and minimal-tests

🤖 Generated with [Claude Code](https://claude.ai/code)