### PR TITLE
Make QML components conditional for builds without QML support

### DIFF
--- a/include/core/Application.h
+++ b/include/core/Application.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <QApplication>
+#ifdef QT6_QML_AVAILABLE
 #include <QQmlApplicationEngine>
+#endif
 #include <memory>
 
 namespace BranchForge::Core {
@@ -18,7 +20,9 @@ private:
     void initializeROS2();
 
     std::unique_ptr<QApplication> m_app;
+#ifdef QT6_QML_AVAILABLE
     std::unique_ptr<QQmlApplicationEngine> m_engine;
+#endif
     bool m_ros2Initialized{false};
 };
 

--- a/include/project/BTSerializer.h
+++ b/include/project/BTSerializer.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <QObject>
+#ifdef QT6_QML_AVAILABLE
 #include <QQmlEngine>
 #include <QJSValue>
+#endif
 #include <QString>
 #include <QVariantMap>
 #include <QVariantList>
@@ -19,8 +21,10 @@ namespace BranchForge::Project {
  */
 class BTSerializer : public QObject {
     Q_OBJECT
+#ifdef QT6_QML_AVAILABLE
     QML_ELEMENT
     QML_SINGLETON
+#endif
 
 public:
     explicit BTSerializer(QObject* parent = nullptr);
@@ -28,6 +32,7 @@ public:
     ~BTSerializer() override;
 
     // QML accessible methods
+#ifdef QT6_QML_AVAILABLE
     Q_INVOKABLE bool serializeToXML(const QVariantMap& editorState, const QString& filePath);
     Q_INVOKABLE QString serializeToString(const QVariantMap& editorState);
     Q_INVOKABLE bool generateCode(const QVariantMap& editorState, const QString& outputDir);
@@ -40,6 +45,7 @@ public:
     // Validation
     Q_INVOKABLE bool validateEditorState(const QVariantMap& editorState);
     Q_INVOKABLE QStringList getValidationErrors() const;
+#endif
     
     // Test-accessible methods
     BehaviorTreeXML convertToBehaviorTreeXML(const QVariantMap& editorState);

--- a/include/ui/MainWindow.h
+++ b/include/ui/MainWindow.h
@@ -1,14 +1,18 @@
 #pragma once
 
 #include <QObject>
+#ifdef QT6_QML_AVAILABLE
 #include <QQmlEngine>
+#endif
 #include <memory>
 
 namespace BranchForge::UI {
 
 class MainWindow : public QObject {
     Q_OBJECT
+#ifdef QT6_QML_AVAILABLE
     QML_ELEMENT
+#endif
 
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(bool isDarkMode READ isDarkMode WRITE setIsDarkMode NOTIFY isDarkModeChanged)


### PR DESCRIPTION
- Add QT6_QML_AVAILABLE guards around all QML includes and usage
- Make QQmlEngine, QQmlApplicationEngine includes conditional
- Add non-QML fallback mode in Application::run() for testing
- Conditional QML type registration and QML_ELEMENT macros
- This allows building and testing core functionality without QML
- Non-QML mode runs component tests and exits successfully

🤖 Generated with [Claude Code](https://claude.ai/code)