### PR TITLE
Fix test library Qt6 linking - make QML/Quick optional for tests too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,10 +145,23 @@ if(BUILD_TESTING)
         Qt6::Widgets
         Qt6::Concurrent
         Qt6::Gui
-        Qt6::Qml
-        Qt6::Quick
-        Qt6::Xml
     )
+    
+    # Link optional Qt6 components if available (same as main target)
+    if(TARGET Qt6::Qml)
+        target_link_libraries(branchforge_test_lib Qt6::Qml)
+        target_compile_definitions(branchforge_test_lib PRIVATE QT6_QML_AVAILABLE)
+    endif()
+
+    if(TARGET Qt6::Quick)
+        target_link_libraries(branchforge_test_lib Qt6::Quick)
+        target_compile_definitions(branchforge_test_lib PRIVATE QT6_QUICK_AVAILABLE)
+    endif()
+
+    if(TARGET Qt6::Xml)
+        target_link_libraries(branchforge_test_lib Qt6::Xml)
+        target_compile_definitions(branchforge_test_lib PRIVATE QT6_XML_AVAILABLE)
+    endif()
     
     # Add test subdirectory
     add_subdirectory(tests)


### PR DESCRIPTION
- Apply same conditional Qt6 component linking to branchforge_test_lib
- Remove hard dependency on Qt6::Qml and Qt6::Quick in test library
- Add same conditional compilation definitions for tests
- This allows test builds to succeed without QML components
- Fixes "Target Qt6::Qml not found" error in test workflows

🤖 Generated with [Claude Code](https://claude.ai/code)