### PR TITLE
Fix remaining QML/XML include issues with conditional compilation

### DIFF
--- a/include/project/BehaviorTreeXML.h
+++ b/include/project/BehaviorTreeXML.h
@@ -3,8 +3,10 @@
 #include <QString>
 #include <QXmlStreamWriter>
 #include <QXmlStreamReader>
+#ifdef QT6_XML_AVAILABLE
 #include <QDomDocument>
 #include <QDomElement>
+#endif
 #include <QList>
 #include <QPointF>
 #include <QMap>
@@ -89,7 +91,9 @@ public:
     void clear();
 
 private:
+#ifdef QT6_XML_AVAILABLE
     void parseXMLNode(const QDomElement& element, const QString& parentId = QString());
+#endif
     void writeXMLNode(QXmlStreamWriter& writer, const BTXMLNode& node) const;
     
     QString generateNodeId() const;
@@ -119,8 +123,10 @@ public:
     static bool validateGrootXML(const QString& xmlContent);
     
 private:
+#ifdef QT6_XML_AVAILABLE
     static QDomDocument parseToDom(const QString& xmlContent);
     static QString domToString(const QDomDocument& doc);
+#endif
 };
 
 } // namespace BranchForge::Project

--- a/include/ros2/ROS2Interface.h
+++ b/include/ros2/ROS2Interface.h
@@ -2,7 +2,9 @@
 
 #include <QObject>
 #include <QTimer>
+#ifdef QT6_QML_AVAILABLE
 #include <QQmlEngine>
+#endif
 #include <QStringList>
 #include <memory>
 #ifdef HAVE_ROS2
@@ -13,8 +15,10 @@ namespace BranchForge::ROS2 {
 
 class ROS2Interface : public QObject {
     Q_OBJECT
+#ifdef QT6_QML_AVAILABLE
     QML_ELEMENT
     QML_SINGLETON
+#endif
 
     Q_PROPERTY(bool isConnected READ isConnected NOTIFY connectionChanged)
     Q_PROPERTY(QStringList availableNodes READ availableNodes NOTIFY nodesChanged)

--- a/src/project/BehaviorTreeXML.cpp
+++ b/src/project/BehaviorTreeXML.cpp
@@ -62,6 +62,7 @@ bool BehaviorTreeXML::importFromFile(const QString& filePath) {
 bool BehaviorTreeXML::importFromString(const QString& xmlContent) {
     qCInfo(btXML) << "Importing BT from XML string";
     
+#ifdef QT6_XML_AVAILABLE
     QDomDocument doc;
     QString errorMsg;
     int errorLine, errorColumn;
@@ -94,6 +95,11 @@ bool BehaviorTreeXML::importFromString(const QString& xmlContent) {
     
     qCInfo(btXML) << "Successfully imported" << m_nodes.size() << "nodes";
     return validateTree();
+#else
+    // Qt6 XML not available - cannot parse DOM
+    qCWarning(btXML) << "XML parsing not available - Qt6::Xml component not installed";
+    return false;
+#endif
 }
 
 bool BehaviorTreeXML::exportToFile(const QString& filePath) const {
@@ -391,6 +397,7 @@ void BehaviorTreeXML::clear() {
     qCDebug(btXML) << "Cleared all tree data";
 }
 
+#ifdef QT6_XML_AVAILABLE
 void BehaviorTreeXML::parseXMLNode(const QDomElement& element, const QString& parentId) {
     BTXMLNode node;
     node.id = element.attribute("id", generateNodeId());
@@ -427,6 +434,7 @@ void BehaviorTreeXML::parseXMLNode(const QDomElement& element, const QString& pa
     
     addNode(node);
 }
+#endif
 
 void BehaviorTreeXML::writeXMLNode(QXmlStreamWriter& writer, const BTXMLNode& node) const {
     writer.writeStartElement("Node");
@@ -470,6 +478,7 @@ bool BehaviorTreeXML::isValidConnection(const QString& parentId, const QString& 
 }
 
 // BTXMLTransformer implementation
+#ifdef QT6_XML_AVAILABLE
 QString BTXMLTransformer::convertFromGroot(const QString& grootXML) {
     // Convert Groot format to BranchForge format
     QDomDocument doc = parseToDom(grootXML);
@@ -541,5 +550,44 @@ QDomDocument BTXMLTransformer::parseToDom(const QString& xmlContent) {
 QString BTXMLTransformer::domToString(const QDomDocument& doc) {
     return doc.toString(2);
 }
+
+#else
+// Qt6 XML not available - provide stub implementations
+QString BTXMLTransformer::convertFromGroot(const QString& grootXML) {
+    Q_UNUSED(grootXML)
+    qCWarning(btXML) << "XML transformations not available - Qt6::Xml component not installed";
+    return QString();
+}
+
+QString BTXMLTransformer::convertFromBehaviorTreeCPP(const QString& btcppXML) {
+    Q_UNUSED(btcppXML)
+    qCWarning(btXML) << "XML transformations not available - Qt6::Xml component not installed";
+    return QString();
+}
+
+QString BTXMLTransformer::convertToGroot(const QString& branchForgeXML) {
+    Q_UNUSED(branchForgeXML)
+    qCWarning(btXML) << "XML transformations not available - Qt6::Xml component not installed";
+    return QString();
+}
+
+QString BTXMLTransformer::convertToBehaviorTreeCPP(const QString& branchForgeXML) {
+    Q_UNUSED(branchForgeXML)
+    qCWarning(btXML) << "XML transformations not available - Qt6::Xml component not installed";
+    return QString();
+}
+
+bool BTXMLTransformer::validateBehaviorTreeCPPXML(const QString& xmlContent) {
+    Q_UNUSED(xmlContent)
+    qCWarning(btXML) << "XML validation not available - Qt6::Xml component not installed";
+    return false;
+}
+
+bool BTXMLTransformer::validateGrootXML(const QString& xmlContent) {
+    Q_UNUSED(xmlContent)
+    qCWarning(btXML) << "XML validation not available - Qt6::Xml component not installed";
+    return false;
+}
+#endif
 
 } // namespace BranchForge::Project


### PR DESCRIPTION
- Make QQmlEngine includes conditional in ROS2Interface.h
- Make QDomDocument/QDomElement includes conditional in BehaviorTreeXML.h
- Add conditional compilation to all QDom-related methods
- Provide stub implementations when Qt6::Xml not available
- Add QML_ELEMENT guards in ROS2Interface.h
- This resolves "QQmlEngine: No such file" and "QDomDocument: No such file" errors

🤖 Generated with [Claude Code](https://claude.ai/code)